### PR TITLE
fix: Update the "Enabled" Toggle to reflect gpg-agent.conf disk state

### DIFF
--- a/Sources/GpgTapNotifier/Views/GpgAgentConfSectionView.swift
+++ b/Sources/GpgTapNotifier/Views/GpgAgentConfSectionView.swift
@@ -94,8 +94,10 @@ struct GpgAgentConfSectionView: View {
         .onChange(of: self.gpgAgentConfPath) { gpgAgentConfPath in
             Task {
                 await self.conf.reload(gpgAgentConfPath)
-                self.syncIsEnabledToggleFromConfig()
             }
+        }
+        .onChange(of: self.conf.isProxyInstalled) { _ in
+            self.syncIsEnabledToggleFromConfig()
         }
     }
 

--- a/Sources/GpgTapNotifier/Views/GpgAgentConfSectionView.swift
+++ b/Sources/GpgTapNotifier/Views/GpgAgentConfSectionView.swift
@@ -20,9 +20,18 @@ struct GpgAgentConfSectionView: View {
     @AppStorage(AppUserDefaults.automaticallyRestartGpgAgent.key, store: AppUserDefaults.suite)
     var automaticallyRestartGpgAgent = AppUserDefaults.automaticallyRestartGpgAgent.getDefault()
 
-    @State private var isEnabledToggleValue: Bool = false
     @State private var isRestartingGpgAgent: Bool = false
 
+    /// The current toggle value. Do not update this outside of the
+    /// `syncIsEnabledToggleFromConfig` function. The sync function manages a
+    /// delicate 2-way binding between the toggle UI state and the config. It
+    /// properly sets the isNextEnabledUpdateFromHuman value.
+    ///
+    /// 2-way binding is a known difficult coding pattern. Ideally the toggle
+    /// value here is a 1-way binding with the config being the source of truth,
+    /// but the SwiftUI `Switch` view does not have a "controlled" mode, to use
+    /// React.js parlance.
+    @State private var isEnabledToggleValue: Bool = false
     /// This stateful value is a workaround for the inability to distinguish
     /// between human interaction of a SwiftUI switch and background updates to
     /// the keep its value up to date. Only the former (human interaction)

--- a/Sources/GpgTapNotifier/Views/GpgAgentConfSectionView.swift
+++ b/Sources/GpgTapNotifier/Views/GpgAgentConfSectionView.swift
@@ -174,15 +174,19 @@ struct GpgAgentConfSectionView: View {
 
     @MainActor
     func onToggleChange(_ nextIsEnabled: Bool) async throws {
-        defer {
-            // Resetting this value back to its default. Any logic in this view is expected
-            // to flip this back to true before toggling.
+        if self.isNextEnabledToggleUpdateBackgroundRefresh {
+            // The Switch was toggled, but only from due to the config changing
+            // on disk outside of this application. In that case there's no need
+            // to edit the config or restart gpg-agent. (Actually a gpg-agent
+            // restart may be required, but that's a complex condition to
+            // check.)
             self.isNextEnabledToggleUpdateBackgroundRefresh = false
+            return
         }
 
         try self.conf.toggle(nextIsEnabled)
 
-        guard !self.isNextEnabledToggleUpdateBackgroundRefresh, self.automaticallyRestartGpgAgent else {
+        guard self.automaticallyRestartGpgAgent else {
             return
         }
 


### PR DESCRIPTION
The UI now stays in sync with manual edits to `gpg-agent.conf`. Video of the now fixed interaction.


https://user-images.githubusercontent.com/906558/172288484-ccf4cf05-c1ee-4a4c-b53e-5dbc9759548b.mov

