### PR TITLE
Add --no-repeat-install flag to enable command

### DIFF
--- a/Sources/GpgTapNotifierUserDefaults/Sources/GpgTapNotifierUserDefaults/GpgTapNotifierUserDefaults.swift
+++ b/Sources/GpgTapNotifierUserDefaults/Sources/GpgTapNotifierUserDefaults/GpgTapNotifierUserDefaults.swift
@@ -50,4 +50,9 @@ public struct AppUserDefaults  {
     public static let customHelpMessage = UserDefaultsConfig<String?>(
         key: "customHelpMessage",
         getDefault: { nil })
+
+    public static let didEnableCommandCompletePreviously = UserDefaultsConfig(
+        key: "didEnableCommandPreviouslyComplete",
+        getDefault: { false }
+    )
 }


### PR DESCRIPTION
Adding a new `--no-repeat-install` flag to the installer.

```
❯ ./GPG\ Tap\ Notifier.app/Contents/Library/GPG\ Tap\ Notifier\ Installer enable --help
USAGE: main-command enable [--no-repeat-install]

OPTIONS:
  --no-repeat-install     Do not perform any actions if this command has already ran.
                          This avoids re-enabling the app on upgrades if users have
                          opened the GUI and disabled it.
  -h, --help              Show help information.
```

## Testing

Quick smoke test to make sure this works as expected.

```
❯ ./GPG\ Tap\ Notifier.app/Contents/Library/GPG\ Tap\ Notifier\ Installer enable --no-repeat-install

❯ cat ~/.gnupg/gpg-agent.conf
default-cache-ttl 600
max-cache-ttl 7200
# --- Start of GPG Tap Notifier Modifications ---
# The lines in this section were automatically added by GPG Tap Notifier.app.
# Any manual edits in this section may be reset. This section can be safely
# deleted if you wish to uninstall the GPG Tap Notifier app.
scdaemon-program /Users/bcheng/Library/Developer/Xcode/DerivedData/GPG_Tap_Notifier-dlkqpxdmlxgdlhaihnrsropwcyzu/Build/Products/Debug/GPG Tap Notifier.app/Contents/Library/GPG Tap Notifier Agent.app/Contents/MacOS/GPG Tap Notifier Agent
# --- End of GPG Tap Notifier Modifications ---

❯ ./GPG\ Tap\ Notifier.app/Contents/Library/GPG\ Tap\ Notifier\ Installer disable

❯ ./GPG\ Tap\ Notifier.app/Contents/Library/GPG\ Tap\ Notifier\ Installer enable --no-repeat-install
Exiting with no modifications. This command has already ran successfully in the past.

❯ cat ~/.gnupg/gpg-agent.conf
default-cache-ttl 600
max-cache-ttl 7200
```