### PR TITLE
feat: Provide NSAlert backed alternative to Notification Center messages

### DIFF
--- a/Sources/GPG Tap Notifier.xcodeproj/project.pbxproj
+++ b/Sources/GPG Tap Notifier.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		46476798284EFC9900A7E6C9 /* DeliveryMechanism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46476797284EFC9900A7E6C9 /* DeliveryMechanism.swift */; };
 		4647679A284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46476799284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift */; };
+		4647679C284F009E00A7E6C9 /* DeliveryMechanismAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4647679B284F009E00A7E6C9 /* DeliveryMechanismAlert.swift */; };
 		830FFF3D283EBFA200D245D2 /* SetCustomHelpMessageCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830FFF3C283EBFA200D245D2 /* SetCustomHelpMessageCommand.swift */; };
 		830FFF3F283EC0E900D245D2 /* UnsetCustomHelpMessageCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830FFF3E283EC0E900D245D2 /* UnsetCustomHelpMessageCommand.swift */; };
 		8310601E27CDEC3A00824D28 /* GPG Tap Notifier Agent.app in CopyFiles */ = {isa = PBXBuildFile; fileRef = 837F1E0A27CADB3300C249DA /* GPG Tap Notifier Agent.app */; };
@@ -65,6 +66,7 @@
 /* Begin PBXFileReference section */
 		46476797284EFC9900A7E6C9 /* DeliveryMechanism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanism.swift; sourceTree = "<group>"; };
 		46476799284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismNotification.swift; sourceTree = "<group>"; };
+		4647679B284F009E00A7E6C9 /* DeliveryMechanismAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismAlert.swift; sourceTree = "<group>"; };
 		830285872804D9CD008B84CF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		830FFF3C283EBFA200D245D2 /* SetCustomHelpMessageCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetCustomHelpMessageCommand.swift; sourceTree = "<group>"; };
 		830FFF3E283EC0E900D245D2 /* UnsetCustomHelpMessageCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsetCustomHelpMessageCommand.swift; sourceTree = "<group>"; };
@@ -221,6 +223,7 @@
 				837F1E0C27CADB3300C249DA /* GpgTapNotifierAgentApp.swift */,
 				837F1E1A27CADF1F00C249DA /* main.swift */,
 				46476797284EFC9900A7E6C9 /* DeliveryMechanism.swift */,
+				4647679B284F009E00A7E6C9 /* DeliveryMechanismAlert.swift */,
 				46476799284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift */,
 				8345C08C27EA37A3000413FF /* ReadCompletionUtils.swift */,
 				837F1E1027CADB3500C249DA /* Assets.xcassets */,
@@ -424,6 +427,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4647679C284F009E00A7E6C9 /* DeliveryMechanismAlert.swift in Sources */,
 				837F1E1B27CADF1F00C249DA /* main.swift in Sources */,
 				837F1E0D27CADB3300C249DA /* GpgTapNotifierAgentApp.swift in Sources */,
 				8345C08D27EA37A3000413FF /* ReadCompletionUtils.swift in Sources */,

--- a/Sources/GPG Tap Notifier.xcodeproj/project.pbxproj
+++ b/Sources/GPG Tap Notifier.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		46476798284EFC9900A7E6C9 /* DeliveryMechanism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46476797284EFC9900A7E6C9 /* DeliveryMechanism.swift */; };
 		4647679A284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46476799284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift */; };
 		4647679C284F009E00A7E6C9 /* DeliveryMechanismAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4647679B284F009E00A7E6C9 /* DeliveryMechanismAlert.swift */; };
+		4693B649285535C500FCD249 /* DeliveryMechanismChooserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4693B648285535C500FCD249 /* DeliveryMechanismChooserView.swift */; };
 		46979AED28552F3E0026C4FD /* AutoReloadingDeliveryMechanism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46979AEC28552F3E0026C4FD /* AutoReloadingDeliveryMechanism.swift */; };
 		830FFF3D283EBFA200D245D2 /* SetCustomHelpMessageCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830FFF3C283EBFA200D245D2 /* SetCustomHelpMessageCommand.swift */; };
 		830FFF3F283EC0E900D245D2 /* UnsetCustomHelpMessageCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830FFF3E283EC0E900D245D2 /* UnsetCustomHelpMessageCommand.swift */; };
@@ -68,6 +69,7 @@
 		46476797284EFC9900A7E6C9 /* DeliveryMechanism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanism.swift; sourceTree = "<group>"; };
 		46476799284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismNotification.swift; sourceTree = "<group>"; };
 		4647679B284F009E00A7E6C9 /* DeliveryMechanismAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismAlert.swift; sourceTree = "<group>"; };
+		4693B648285535C500FCD249 /* DeliveryMechanismChooserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismChooserView.swift; sourceTree = "<group>"; };
 		46979AEC28552F3E0026C4FD /* AutoReloadingDeliveryMechanism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoReloadingDeliveryMechanism.swift; sourceTree = "<group>"; };
 		830285872804D9CD008B84CF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		830FFF3C283EBFA200D245D2 /* SetCustomHelpMessageCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetCustomHelpMessageCommand.swift; sourceTree = "<group>"; };
@@ -139,6 +141,7 @@
 				83C2E71A27E4464900FB7743 /* FilePathsView.swift */,
 				837FD81927E6AB5000CDD61B /* FilePathItemView.swift */,
 				837FD81B27E6BA3500CDD61B /* NotificationMessageEditView.swift */,
+				4693B648285535C500FCD249 /* DeliveryMechanismChooserView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -414,6 +417,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4693B649285535C500FCD249 /* DeliveryMechanismChooserView.swift in Sources */,
 				837FD81A27E6AB5000CDD61B /* FilePathItemView.swift in Sources */,
 				835F7A9527DEC8C60046D482 /* GpgAgentConfViewModel.swift in Sources */,
 				837F1DFA27CADB1F00C249DA /* ContentView.swift in Sources */,

--- a/Sources/GPG Tap Notifier.xcodeproj/project.pbxproj
+++ b/Sources/GPG Tap Notifier.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		46476798284EFC9900A7E6C9 /* DeliveryMechanism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46476797284EFC9900A7E6C9 /* DeliveryMechanism.swift */; };
+		4647679A284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46476799284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift */; };
 		830FFF3D283EBFA200D245D2 /* SetCustomHelpMessageCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830FFF3C283EBFA200D245D2 /* SetCustomHelpMessageCommand.swift */; };
 		830FFF3F283EC0E900D245D2 /* UnsetCustomHelpMessageCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830FFF3E283EC0E900D245D2 /* UnsetCustomHelpMessageCommand.swift */; };
 		8310601E27CDEC3A00824D28 /* GPG Tap Notifier Agent.app in CopyFiles */ = {isa = PBXBuildFile; fileRef = 837F1E0A27CADB3300C249DA /* GPG Tap Notifier Agent.app */; };
@@ -61,6 +63,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		46476797284EFC9900A7E6C9 /* DeliveryMechanism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanism.swift; sourceTree = "<group>"; };
+		46476799284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismNotification.swift; sourceTree = "<group>"; };
 		830285872804D9CD008B84CF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		830FFF3C283EBFA200D245D2 /* SetCustomHelpMessageCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetCustomHelpMessageCommand.swift; sourceTree = "<group>"; };
 		830FFF3E283EC0E900D245D2 /* UnsetCustomHelpMessageCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsetCustomHelpMessageCommand.swift; sourceTree = "<group>"; };
@@ -216,6 +220,8 @@
 				837F1E1927CADD7500C249DA /* Info.plist */,
 				837F1E0C27CADB3300C249DA /* GpgTapNotifierAgentApp.swift */,
 				837F1E1A27CADF1F00C249DA /* main.swift */,
+				46476797284EFC9900A7E6C9 /* DeliveryMechanism.swift */,
+				46476799284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift */,
 				8345C08C27EA37A3000413FF /* ReadCompletionUtils.swift */,
 				837F1E1027CADB3500C249DA /* Assets.xcassets */,
 				837F1E1527CADB3500C249DA /* GpgTapNotifierAgent.entitlements */,
@@ -421,6 +427,8 @@
 				837F1E1B27CADF1F00C249DA /* main.swift in Sources */,
 				837F1E0D27CADB3300C249DA /* GpgTapNotifierAgentApp.swift in Sources */,
 				8345C08D27EA37A3000413FF /* ReadCompletionUtils.swift in Sources */,
+				4647679A284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift in Sources */,
+				46476798284EFC9900A7E6C9 /* DeliveryMechanism.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/GPG Tap Notifier.xcodeproj/project.pbxproj
+++ b/Sources/GPG Tap Notifier.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		46476798284EFC9900A7E6C9 /* DeliveryMechanism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46476797284EFC9900A7E6C9 /* DeliveryMechanism.swift */; };
 		4647679A284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46476799284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift */; };
 		4647679C284F009E00A7E6C9 /* DeliveryMechanismAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4647679B284F009E00A7E6C9 /* DeliveryMechanismAlert.swift */; };
+		46979AED28552F3E0026C4FD /* AutoReloadingDeliveryMechanism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46979AEC28552F3E0026C4FD /* AutoReloadingDeliveryMechanism.swift */; };
 		830FFF3D283EBFA200D245D2 /* SetCustomHelpMessageCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830FFF3C283EBFA200D245D2 /* SetCustomHelpMessageCommand.swift */; };
 		830FFF3F283EC0E900D245D2 /* UnsetCustomHelpMessageCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830FFF3E283EC0E900D245D2 /* UnsetCustomHelpMessageCommand.swift */; };
 		8310601E27CDEC3A00824D28 /* GPG Tap Notifier Agent.app in CopyFiles */ = {isa = PBXBuildFile; fileRef = 837F1E0A27CADB3300C249DA /* GPG Tap Notifier Agent.app */; };
@@ -67,6 +68,7 @@
 		46476797284EFC9900A7E6C9 /* DeliveryMechanism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanism.swift; sourceTree = "<group>"; };
 		46476799284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismNotification.swift; sourceTree = "<group>"; };
 		4647679B284F009E00A7E6C9 /* DeliveryMechanismAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismAlert.swift; sourceTree = "<group>"; };
+		46979AEC28552F3E0026C4FD /* AutoReloadingDeliveryMechanism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoReloadingDeliveryMechanism.swift; sourceTree = "<group>"; };
 		830285872804D9CD008B84CF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		830FFF3C283EBFA200D245D2 /* SetCustomHelpMessageCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetCustomHelpMessageCommand.swift; sourceTree = "<group>"; };
 		830FFF3E283EC0E900D245D2 /* UnsetCustomHelpMessageCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsetCustomHelpMessageCommand.swift; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 				837F1E1927CADD7500C249DA /* Info.plist */,
 				837F1E0C27CADB3300C249DA /* GpgTapNotifierAgentApp.swift */,
 				837F1E1A27CADF1F00C249DA /* main.swift */,
+				46979AEC28552F3E0026C4FD /* AutoReloadingDeliveryMechanism.swift */,
 				46476797284EFC9900A7E6C9 /* DeliveryMechanism.swift */,
 				4647679B284F009E00A7E6C9 /* DeliveryMechanismAlert.swift */,
 				46476799284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift */,
@@ -430,6 +433,7 @@
 				4647679C284F009E00A7E6C9 /* DeliveryMechanismAlert.swift in Sources */,
 				837F1E1B27CADF1F00C249DA /* main.swift in Sources */,
 				837F1E0D27CADB3300C249DA /* GpgTapNotifierAgentApp.swift in Sources */,
+				46979AED28552F3E0026C4FD /* AutoReloadingDeliveryMechanism.swift in Sources */,
 				8345C08D27EA37A3000413FF /* ReadCompletionUtils.swift in Sources */,
 				4647679A284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift in Sources */,
 				46476798284EFC9900A7E6C9 /* DeliveryMechanism.swift in Sources */,

--- a/Sources/GpgTapNotifier/ContentView.swift
+++ b/Sources/GpgTapNotifier/ContentView.swift
@@ -50,6 +50,9 @@ struct ContentView: View {
                 scdaemonPath: self.scdaemonPath)
                 .padding(.vertical)
 
+            DeliveryMechanismChooserView()
+                .padding(.vertical)
+
             Divider()
 
             FilePathsView(

--- a/Sources/GpgTapNotifier/Views/DeliveryMechanismChooserView.swift
+++ b/Sources/GpgTapNotifier/Views/DeliveryMechanismChooserView.swift
@@ -1,0 +1,26 @@
+// Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import SwiftUI
+import GpgTapNotifierUserDefaults
+
+struct DeliveryMechanismChooserView: View {
+    @AppStorage(AppUserDefaults.reminderDeliveryMechanism.key, store: AppUserDefaults.suite)
+    var reminderDeliveryMechanism = AppUserDefaults.reminderDeliveryMechanism.getDefault()
+
+    // TODO: Describe the various delivery mechanisms.
+    // TODO: Provide a way to test a notification.
+    var body: some View {
+        VStack {
+            Picker("Delivery Mechanism", selection: $reminderDeliveryMechanism) {
+                ForEach(ReminderDeliveryMechanismOption.allCases) { Text($0.description) }
+            }.pickerStyle(.segmented)
+        }
+    }
+}
+
+struct DeliveryMechanismChooserView_Previews: PreviewProvider {
+    static var previews: some View {
+        DeliveryMechanismChooserView()
+    }
+}

--- a/Sources/GpgTapNotifierAgent/AutoReloadingDeliveryMechanism.swift
+++ b/Sources/GpgTapNotifierAgent/AutoReloadingDeliveryMechanism.swift
@@ -1,0 +1,47 @@
+// Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import Foundation
+import GpgTapNotifierUserDefaults
+
+class AutoReloadingDeliveryMechanism {
+    private var cachedDeliveryMechanism: CachedDeliveryMechansim?
+
+    func get() -> DeliveryMechanism {
+        let currentDeliveryMechanismOption = readCurrentDeliveryMechanismOption()
+        if let cached = cachedDeliveryMechanism, cached.optionValue == currentDeliveryMechanismOption {
+            return cached.deliveryMechanism
+        }
+
+        // If the user changes the config value while a reminder notification is
+        // still shown, we should take care to close it and not leave it on the
+        // the screen forever.
+        cachedDeliveryMechanism?.deliveryMechanism.dismiss()
+
+        let deliveryMechanism = mapReminderToDeliveryMechanism(currentDeliveryMechanismOption)
+        cachedDeliveryMechanism = CachedDeliveryMechansim(
+            deliveryMechanism: deliveryMechanism,
+            optionValue: currentDeliveryMechanismOption)
+
+        return deliveryMechanism
+    }
+}
+
+private struct CachedDeliveryMechansim  {
+    var deliveryMechanism: DeliveryMechanism
+    let optionValue: ReminderDeliveryMechanismOption
+}
+
+private func mapReminderToDeliveryMechanism(_ option: ReminderDeliveryMechanismOption) -> DeliveryMechanism {
+    switch option {
+    case .notificationCenter: return DeliveryMechanismNotification()
+    case .alert: return DeliveryMechanismAlert()
+    }
+}
+
+private func readCurrentDeliveryMechanismOption() -> ReminderDeliveryMechanismOption {
+    let storedValue = AppUserDefaults.suite?.integer(forKey: AppUserDefaults.reminderDeliveryMechanism.key)
+    return storedValue
+        .flatMap { ReminderDeliveryMechanismOption(rawValue: $0) }
+        ?? AppUserDefaults.reminderDeliveryMechanism.getDefault()
+}

--- a/Sources/GpgTapNotifierAgent/DeliveryMechanism.swift
+++ b/Sources/GpgTapNotifierAgent/DeliveryMechanism.swift
@@ -1,0 +1,19 @@
+// Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import Foundation
+
+/// Protocol to abstract different delivery mechanisms for providing tap
+/// reminders.
+protocol DeliveryMechanism {
+    /// Called when scdaemon's response exceeds the configured timeout. The
+    /// dismiss function is not guaranteed to be called before this function is
+    /// called again.
+    mutating func present(title: String, body: String)
+
+    /// Called on any scdaemon response. The present function is not guaranteed
+    /// to be called before this function. The DeliveryMechanism implementation
+    /// should store internal state on whether or not a true dismissal is
+    /// necessary.
+    mutating func dismiss()
+}

--- a/Sources/GpgTapNotifierAgent/DeliveryMechanismAlert.swift
+++ b/Sources/GpgTapNotifierAgent/DeliveryMechanismAlert.swift
@@ -1,0 +1,52 @@
+// Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import AppKit
+import Foundation
+
+class DeliveryMechanismAlert {
+    private lazy var alertWindow: NSPanel = {
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 0, height: 0),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false)
+
+        panel.center()
+        panel.isFloatingPanel = true
+
+        return panel
+    }()
+
+    private var currentAlert: NSAlert?
+}
+
+extension DeliveryMechanismAlert: DeliveryMechanism {
+    func present(title: String, body: String) {
+        guard self.currentAlert == nil else {
+            return
+        }
+
+        let alert = NSAlert()
+
+        alert.messageText = title
+        alert.informativeText = body
+        alert.alertStyle = .informational
+
+        alert.addButton(withTitle: "Close")
+
+        self.currentAlert = alert
+
+        alert.beginSheetModal(for: alertWindow) { _ in
+            self.currentAlert = nil
+        }
+    }
+
+    func dismiss() {
+        guard let alert = currentAlert else {
+            return
+        }
+        self.currentAlert = nil
+        alertWindow.endSheet(alert.window)
+    }
+}

--- a/Sources/GpgTapNotifierAgent/DeliveryMechanismAlert.swift
+++ b/Sources/GpgTapNotifierAgent/DeliveryMechanismAlert.swift
@@ -12,7 +12,6 @@ class DeliveryMechanismAlert {
             backing: .buffered,
             defer: false)
 
-        panel.center()
         panel.isFloatingPanel = true
 
         return panel
@@ -39,6 +38,11 @@ extension DeliveryMechanismAlert: DeliveryMechanism {
         alert.addButton(withTitle: "Open Configuration")
 
         self.currentAlert = alert
+
+        // During testing the invisible alert window somehow moved to the bottom
+        // left between reminders. Always center this window before we show the
+        // alert as a workaround.
+        alertWindow.center()
 
         alert.beginSheetModal(for: alertWindow) { modalResponse in
             self.currentAlert = nil

--- a/Sources/GpgTapNotifierAgent/DeliveryMechanismNotification.swift
+++ b/Sources/GpgTapNotifierAgent/DeliveryMechanismNotification.swift
@@ -1,0 +1,47 @@
+// Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import Foundation
+import os
+import UserNotifications
+
+class DeliveryMechanismNotification {
+    let logger = Logger()
+    var currentNotificationIdentifier: String?
+}
+
+extension DeliveryMechanismNotification: DeliveryMechanism {
+    func present(title: String, body: String) {
+        let content = UNMutableNotificationContent()
+
+        content.title = title
+        content.body = body
+
+        // Always play a sound by default. Users can disable this in System Preferences.
+        // TODO: Consider making what sound plays configurable.
+        content.sound = .default
+
+        let currentNotificationIdentifier = UUID().uuidString
+        self.currentNotificationIdentifier = currentNotificationIdentifier
+        let request = UNNotificationRequest(identifier: currentNotificationIdentifier, content: content, trigger: nil)
+
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                self.logger.error("Failed to deliver notification: \(error.localizedDescription)")
+
+                if self.currentNotificationIdentifier == currentNotificationIdentifier {
+                    self.currentNotificationIdentifier = nil
+                }
+            }
+        }
+    }
+
+    func dismiss() {
+        guard let identifier = self.currentNotificationIdentifier else {
+            return
+        }
+
+        self.currentNotificationIdentifier = nil
+        UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [identifier])
+    }
+}

--- a/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
+++ b/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
@@ -122,13 +122,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     return
                 }
 
-                self.sendNotification()
+                self.presentReminder()
             }
         }
 
         NotificationCenter.default.addObserver(forName: FileHandle.readCompletionNotification, object: scdaemonStdOut.fileHandleForReading, queue: .main) { notification in
             notificationTask?.cancel()
-            self.removeDeliveredNotification()
+            self.dismissReminder()
 
             let data = try! readCompletionResult(notification.userInfo!).get()
             try! FileHandle.standardOutput.write(contentsOf: data)
@@ -138,7 +138,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         NotificationCenter.default.addObserver(forName: FileHandle.readCompletionNotification, object: scdaemonStdErr.fileHandleForReading, queue: .main) { notification in
             notificationTask?.cancel()
-            self.removeDeliveredNotification()
+            self.dismissReminder()
 
             let data = try! readCompletionResult(notification.userInfo!).get()
             try! FileHandle.standardError.write(contentsOf: data)
@@ -153,7 +153,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return scdaemon
     }
 
-    private func sendNotification() {
+    private func presentReminder() {
         // Intentionally reading from UserDefaults on every notification rather than
         // setting up a Key-Value Observer (KVO). The KVO adds implementation complexity
         // and notifications aren't sent frequently enough to be worth caching.
@@ -163,7 +163,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         deliveryMechanism.present(title: title, body: body)
     }
 
-    private func removeDeliveredNotification() {
+    private func dismissReminder() {
         deliveryMechanism.dismiss()
     }
 }

--- a/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
+++ b/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
@@ -122,13 +122,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     return
                 }
 
-                self.presentReminder()
+                await self.presentReminder()
             }
         }
 
         NotificationCenter.default.addObserver(forName: FileHandle.readCompletionNotification, object: scdaemonStdOut.fileHandleForReading, queue: .main) { notification in
             notificationTask?.cancel()
-            self.dismissReminder()
+            Task { await self.dismissReminder() }
 
             let data = try! readCompletionResult(notification.userInfo!).get()
             try! FileHandle.standardOutput.write(contentsOf: data)
@@ -138,7 +138,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         NotificationCenter.default.addObserver(forName: FileHandle.readCompletionNotification, object: scdaemonStdErr.fileHandleForReading, queue: .main) { notification in
             notificationTask?.cancel()
-            self.dismissReminder()
+            Task { await self.dismissReminder() }
 
             let data = try! readCompletionResult(notification.userInfo!).get()
             try! FileHandle.standardError.write(contentsOf: data)
@@ -153,6 +153,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return scdaemon
     }
 
+    @MainActor
     private func presentReminder() {
         // Intentionally reading from UserDefaults on every notification rather than
         // setting up a Key-Value Observer (KVO). The KVO adds implementation complexity
@@ -163,6 +164,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         deliveryMechanism.present(title: title, body: body)
     }
 
+    @MainActor
     private func dismissReminder() {
         deliveryMechanism.dismiss()
     }

--- a/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
+++ b/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
@@ -22,6 +22,7 @@ import GpgTapNotifierUserDefaults
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     let logger = Logger()
+    // TODO: Add config to allow swapping delivery mechanisms.
     let deliveryMechanism = DeliveryMechanismNotification()
 
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
+++ b/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
@@ -22,7 +22,6 @@ import GpgTapNotifierUserDefaults
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     let logger = Logger()
-    // TODO: Allow the user to change the delivery mechanism in the UI.
     var autoReloadingDeliveryMechanism = AutoReloadingDeliveryMechanism()
 
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
+++ b/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
@@ -22,8 +22,8 @@ import GpgTapNotifierUserDefaults
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     let logger = Logger()
-    // TODO: Add config to allow swapping delivery mechanisms.
-    let deliveryMechanism = DeliveryMechanismNotification()
+    // TODO: Allow the user to change the delivery mechanism in the UI.
+    var autoReloadingDeliveryMechanism = AutoReloadingDeliveryMechanism()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // TODO: Create a security scoped bookmark for the scdaemon path and read so this agent works when sandboxed.
@@ -162,11 +162,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let title = AppUserDefaults.suite?.string(forKey: AppUserDefaults.notificationTitle.key) ?? AppUserDefaults.notificationTitle.getDefault()
         let body = AppUserDefaults.suite?.string(forKey: AppUserDefaults.notificationBody.key) ?? AppUserDefaults.notificationBody.getDefault()
 
+        var deliveryMechanism = autoReloadingDeliveryMechanism.get()
         deliveryMechanism.present(title: title, body: body)
     }
 
     @MainActor
     private func dismissReminder() {
+        var deliveryMechanism = autoReloadingDeliveryMechanism.get()
         deliveryMechanism.dismiss()
     }
 }

--- a/Sources/GpgTapNotifierUserDefaults/Sources/GpgTapNotifierUserDefaults/GpgTapNotifierUserDefaults.swift
+++ b/Sources/GpgTapNotifierUserDefaults/Sources/GpgTapNotifierUserDefaults/GpgTapNotifierUserDefaults.swift
@@ -31,6 +31,10 @@ public struct AppUserDefaults  {
         key: "gpgconfPath",
         getDefault: { "/usr/local/MacGPG2/bin/gpgconf" })
 
+    public static let reminderDeliveryMechanism = UserDefaultsConfig(
+        key: "reminderDeliveryMechanism",
+        getDefault: { ReminderDeliveryMechanismOption.notificationCenter })
+
     public static let notificationTimeoutSecs = UserDefaultsConfig(
         key: "notificationTimeoutSecs",
         getDefault: { 1.0 })

--- a/Sources/GpgTapNotifierUserDefaults/Sources/GpgTapNotifierUserDefaults/ReminderDeliveryMechanismOption.swift
+++ b/Sources/GpgTapNotifierUserDefaults/Sources/GpgTapNotifierUserDefaults/ReminderDeliveryMechanismOption.swift
@@ -1,7 +1,20 @@
 // Copyright 2022 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-public enum ReminderDeliveryMechanismOption: Int {
+public enum ReminderDeliveryMechanismOption: Int, CaseIterable {
     case notificationCenter = 1
     case alert
+}
+
+extension ReminderDeliveryMechanismOption : Identifiable {
+    public var id: Self { self }
+}
+
+extension ReminderDeliveryMechanismOption: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .notificationCenter: return "Notification Center"
+        case .alert: return "System Alert"
+        }
+    }
 }

--- a/Sources/GpgTapNotifierUserDefaults/Sources/GpgTapNotifierUserDefaults/ReminderDeliveryMechanismOption.swift
+++ b/Sources/GpgTapNotifierUserDefaults/Sources/GpgTapNotifierUserDefaults/ReminderDeliveryMechanismOption.swift
@@ -1,0 +1,7 @@
+// Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+public enum ReminderDeliveryMechanismOption: Int {
+    case notificationCenter = 1
+    case alert
+}


### PR DESCRIPTION
This PR implements a reminder mechanism driven by [`NSAlert`](https://developer.apple.com/documentation/appkit/nsalert).

<img width="328" alt="Screen Shot 2022-06-11 at 6 28 29 PM" src="https://user-images.githubusercontent.com/906558/173206875-92263c6d-c675-45ce-be3e-9a45c0ef7e1a.png">

Here's a video of the alert being shown and dismissed.

https://user-images.githubusercontent.com/906558/173206854-94fcfabe-62ca-4ba9-bf46-a852541724a8.mov

Switching between the 2 delivery mechanisms does not require a restart.

https://user-images.githubusercontent.com/906558/173206853-269f09f4-f4fd-4c49-8a2e-3c4a8c3b8891.mov