### PR TITLE
fix: Remove existing notifications before presenting another 

### DIFF
--- a/Sources/GpgTapNotifierAgent/DeliveryMechanismNotification.swift
+++ b/Sources/GpgTapNotifierAgent/DeliveryMechanismNotification.swift
@@ -56,6 +56,16 @@ extension DeliveryMechanismNotification: DeliveryMechanism {
     func present(title: String, body: String) {
         performSetupIfNecessary()
 
+        if let currentNotificationIdentifier = self.currentNotificationIdentifier {
+            self.currentNotificationIdentifier = nil
+
+            // This shouldn't happen in practice, but if the present() function
+            // is called multiple times without dismiss(), remove any existing
+            // notifications and present a new one. It's not clear if this is the right
+            // behavior, but it'll make any new reminders more prominent.
+            UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [currentNotificationIdentifier])
+        }
+
         let content = UNMutableNotificationContent()
 
         content.title = title


### PR DESCRIPTION
The agent's current behavior is to display multiple notifications at once if the `present()` method is called sequentially without an intermediate `dismiss()` call.

In theory this can happen if users GPG sign in different terminal tabs without acting on previous sign requests. In this case, only the latest notification would be cleared, which is a bug.

This change was prompted by a future commit refactoring `present()` to be an async method. The `checkedContinuation` API forced better handling of this scenario since a continuation discarded without resuming log a warning.