### PR TITLE
Add button to test notifications in the config UI

### DIFF
--- a/Sources/GPG Tap Notifier.xcodeproj/project.pbxproj
+++ b/Sources/GPG Tap Notifier.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		46476798284EFC9900A7E6C9 /* DeliveryMechanism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46476797284EFC9900A7E6C9 /* DeliveryMechanism.swift */; };
 		4647679A284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46476799284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift */; };
 		4647679C284F009E00A7E6C9 /* DeliveryMechanismAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4647679B284F009E00A7E6C9 /* DeliveryMechanismAlert.swift */; };
+		464CDAF72870EFE300EAF1AD /* DeliveryMechanismTestButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464CDAF62870EFE300EAF1AD /* DeliveryMechanismTestButtonView.swift */; };
 		464CDAF92870F3E800EAF1AD /* ProgressViewLoadingGpgConf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464CDAF82870F3E800EAF1AD /* ProgressViewLoadingGpgConf.swift */; };
 		4693B649285535C500FCD249 /* DeliveryMechanismChooserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4693B648285535C500FCD249 /* DeliveryMechanismChooserView.swift */; };
 		46979AED28552F3E0026C4FD /* AutoReloadingDeliveryMechanism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46979AEC28552F3E0026C4FD /* AutoReloadingDeliveryMechanism.swift */; };
@@ -74,6 +75,7 @@
 		46476797284EFC9900A7E6C9 /* DeliveryMechanism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanism.swift; sourceTree = "<group>"; };
 		46476799284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismNotification.swift; sourceTree = "<group>"; };
 		4647679B284F009E00A7E6C9 /* DeliveryMechanismAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismAlert.swift; sourceTree = "<group>"; };
+		464CDAF62870EFE300EAF1AD /* DeliveryMechanismTestButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismTestButtonView.swift; sourceTree = "<group>"; };
 		464CDAF82870F3E800EAF1AD /* ProgressViewLoadingGpgConf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressViewLoadingGpgConf.swift; sourceTree = "<group>"; };
 		4693B648285535C500FCD249 /* DeliveryMechanismChooserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismChooserView.swift; sourceTree = "<group>"; };
 		46979AEC28552F3E0026C4FD /* AutoReloadingDeliveryMechanism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoReloadingDeliveryMechanism.swift; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 				4693B648285535C500FCD249 /* DeliveryMechanismChooserView.swift */,
 				46A442562856FA980012CE9A /* DeliveryMechanismChoiceView.swift */,
 				46F28612286FFD440071C8C1 /* DeliveryMechanismChoicePreviewView.swift */,
+				464CDAF62870EFE300EAF1AD /* DeliveryMechanismTestButtonView.swift */,
 				464CDAF82870F3E800EAF1AD /* ProgressViewLoadingGpgConf.swift */,
 			);
 			path = Views;
@@ -439,6 +442,7 @@
 				83C2E71B27E4464900FB7743 /* FilePathsView.swift in Sources */,
 				837F1DF827CADB1F00C249DA /* GpgTapNotifierApp.swift in Sources */,
 				837FD81C27E6BA3500CDD61B /* NotificationMessageEditView.swift in Sources */,
+				464CDAF72870EFE300EAF1AD /* DeliveryMechanismTestButtonView.swift in Sources */,
 				835F7A9327DE87D30046D482 /* AsyncUtils.swift in Sources */,
 				46A442572856FA980012CE9A /* DeliveryMechanismChoiceView.swift in Sources */,
 				831CC8A127D07D0F002D8A6D /* Constants.swift in Sources */,

--- a/Sources/GpgTapNotifier/Views/DeliveryMechanismChooserView.swift
+++ b/Sources/GpgTapNotifier/Views/DeliveryMechanismChooserView.swift
@@ -27,6 +27,11 @@ struct DeliveryMechanismChooserView: View {
                 .foregroundColor(.secondary)
                 .lineLimit(3)
                 .fixedSize(horizontal: false, vertical: true)
+
+            HStack {
+                Spacer()
+                DeliveryMechanismTestButtonView()
+            }
         }
     }
 

--- a/Sources/GpgTapNotifier/Views/DeliveryMechanismTestButtonView.swift
+++ b/Sources/GpgTapNotifier/Views/DeliveryMechanismTestButtonView.swift
@@ -1,0 +1,61 @@
+// Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import SwiftUI
+
+struct DeliveryMechanismTestButtonView: View {
+    @State private var isTestingNotification = false
+
+    @State private var isErrorPopoverShown = false
+    @State private var lastError: Error?
+
+    var body: some View {
+        HStack {
+            Button(action: { isErrorPopoverShown = true }) {
+                Image(systemName: "exclamationmark.circle")
+            }
+            .disabled(lastError == nil)
+            .opacity(lastError == nil ? 0 : 1)
+            .buttonStyle(.plain)
+            .foregroundColor(.red)
+            .popover(isPresented: $isErrorPopoverShown) {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("The last notification test failed")
+                    Text(lastError.map { $0.localizedDescription } ?? "")
+                        .font(.caption)
+                }
+                .padding(10)
+                .frame(width: 250)
+            }
+
+            Button(action: onClick) {
+                Text("Test Notification")
+            }
+            .disabled(isTestingNotification)
+        }
+    }
+
+    func onClick() {
+        Task {
+            self.isTestingNotification = true
+            self.lastError = nil
+            defer { self.isTestingNotification = false }
+
+            do {
+                try await testNotification()
+            } catch {
+                self.lastError = error
+            }
+        }
+    }
+}
+
+struct DeliveryMechanismTestView_Previews: PreviewProvider {
+    static var previews: some View {
+        DeliveryMechanismTestButtonView()
+    }
+}
+
+func testNotification() async throws {
+    try await run(AGENT_BIN_PATH, arguments: ["--gpg-tap-notifier-test-notification"])
+}

--- a/Sources/GpgTapNotifierAgent/DeliveryMechanism.swift
+++ b/Sources/GpgTapNotifierAgent/DeliveryMechanism.swift
@@ -9,11 +9,25 @@ protocol DeliveryMechanism {
     /// Called when scdaemon's response exceeds the configured timeout. The
     /// dismiss function is not guaranteed to be called before this function is
     /// called again.
-    mutating func present(title: String, body: String)
+    mutating func present(title: String, body: String) async -> PresentStopReason
 
     /// Called on any scdaemon response. The present function is not guaranteed
     /// to be called before this function. The DeliveryMechanism implementation
     /// should store internal state on whether or not a true dismissal is
     /// necessary.
     mutating func dismiss()
+}
+
+enum PresentStopReason {
+    /// The reminder was removed from the screen during normal operation. (i.e.
+    /// The scdaemon process began responding.)
+    case dismissed
+    /// The user clicked on the notification (cause it to be cleared) or clicked
+    /// the alert dismiss button.
+    case userManuallyCleared
+    /// There's already a reminder being displayed.
+    case existingReminderDisplayed
+    /// The current reminder was replaced with a new one.
+    case reminderReplaced
+    case deliveryError(Error)
 }

--- a/Sources/GpgTapNotifierAgent/DeliveryMechanismAlert.swift
+++ b/Sources/GpgTapNotifierAgent/DeliveryMechanismAlert.swift
@@ -17,13 +17,20 @@ class DeliveryMechanismAlert {
         return panel
     }()
 
-    private var currentAlert: NSAlert?
+    struct PresentingState {
+        let continuation: CheckedContinuation<PresentStopReason, Never>
+        let currentAlert: NSAlert
+    }
+
+    /// Non-nil if an alert is currently displayed.
+    private var presentingState: PresentingState? = nil
 }
 
 extension DeliveryMechanismAlert: DeliveryMechanism {
-    func present(title: String, body: String) {
-        guard self.currentAlert == nil else {
-            return
+    @MainActor
+    func present(title: String, body: String) async -> PresentStopReason {
+        guard presentingState == nil else {
+            return .existingReminderDisplayed
         }
 
         let alert = NSAlert()
@@ -37,29 +44,35 @@ extension DeliveryMechanismAlert: DeliveryMechanism {
         alert.addButton(withTitle: "Close")
         alert.addButton(withTitle: "Open Configuration")
 
-        self.currentAlert = alert
-
         // During testing the invisible alert window somehow moved to the bottom
         // left between reminders. Always center this window before we show the
         // alert as a workaround.
         alertWindow.center()
 
-        alert.beginSheetModal(for: alertWindow) { modalResponse in
-            self.currentAlert = nil
+        return await withCheckedContinuation { (continuation: CheckedContinuation<PresentStopReason, Never>) in
+            let presentingState = PresentingState(continuation: continuation, currentAlert: alert)
+            self.presentingState = presentingState
 
-            // Corresponds with the "Open Configuration" button since it was
-            // added second. What a strange API.
-            if modalResponse == NSApplication.ModalResponse.alertSecondButtonReturn {
-                openConfigurationApp()
+            alert.beginSheetModal(for: alertWindow) { modalResponse in
+                self.presentingState = nil
+                presentingState.continuation.resume(returning: .userManuallyCleared)
+
+                // Corresponds with the "Open Configuration" button since it was
+                // added second. What a strange API.
+                if modalResponse == NSApplication.ModalResponse.alertSecondButtonReturn {
+                    openConfigurationApp()
+                }
             }
         }
     }
 
     func dismiss() {
-        guard let alert = currentAlert else {
+        guard let presentingState = presentingState else {
             return
         }
-        self.currentAlert = nil
-        alertWindow.endSheet(alert.window)
+        self.presentingState = nil
+
+        presentingState.continuation.resume(returning: .dismissed)
+        alertWindow.endSheet(presentingState.currentAlert.window)
     }
 }

--- a/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
+++ b/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
@@ -143,7 +143,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @MainActor
-    private func presentReminder() {
+    private func presentReminder() async {
         // Intentionally reading from UserDefaults on every notification rather than
         // setting up a Key-Value Observer (KVO). The KVO adds implementation complexity
         // and notifications aren't sent frequently enough to be worth caching.
@@ -151,7 +151,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let body = AppUserDefaults.suite?.string(forKey: AppUserDefaults.notificationBody.key) ?? AppUserDefaults.notificationBody.getDefault()
 
         var deliveryMechanism = autoReloadingDeliveryMechanism.get()
-        deliveryMechanism.present(title: title, body: body)
+        let _ = await deliveryMechanism.present(title: title, body: body)
     }
 
     @MainActor


### PR DESCRIPTION
## Changes

Adding a new "_Test Notification_" button. If users haven't authorized notifications from the agent yet, clicking the test button will ask for permission.

<img width="637" alt="Screen Shot 2022-07-03 at 12 56 19 PM" src="https://user-images.githubusercontent.com/906558/177049698-3a6c763e-4e21-4595-8947-a80ade54f987.png">

## Demo

https://user-images.githubusercontent.com/906558/177049660-a982a17a-115b-4d01-8b9d-fa09ba29bdac.mov

