### PR TITLE
fix: Wait for notification authorization before sending first reminder

### DIFF
--- a/Sources/GpgTapNotifierAgent/DeliveryMechanismNotification.swift
+++ b/Sources/GpgTapNotifierAgent/DeliveryMechanismNotification.swift
@@ -28,6 +28,9 @@ class DeliveryMechanismNotification: NSObject {
         return [category]
     }
 
+    // For some reason .badge permissions are also required for .sound: https://stackoverflow.com/a/70499458
+    private let notificationOptions: UNAuthorizationOptions = [.alert, .badge, .sound, .providesAppNotificationSettings]
+
     private func performSetupIfNecessary() {
         guard !didPerformSetup else {
             return
@@ -45,8 +48,7 @@ class DeliveryMechanismNotification: NSObject {
         UNUserNotificationCenter.current().setNotificationCategories(getNotificationCategories())
         UNUserNotificationCenter.current().delegate = self
 
-        // For some reason .badge permissions are also required for .sound: https://stackoverflow.com/a/70499458
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound, .providesAppNotificationSettings]) { granted, error in
+        UNUserNotificationCenter.current().requestAuthorization(options: notificationOptions) { granted, error in
             if !granted {
                 self.logger.error("User did not authorize notifications.")
             }


### PR DESCRIPTION
Before this change, the agent would request authorization to display notifications and send the initial tap reminder at the same time.

This results in a minor bug where the initial tap reminder would always fail to display.

The agent now properly waits for `requestAuthorization()` before presenting any notifications. If the smart card has not yet been tapped, the reminder will display after the user accepts notifications.

https://user-images.githubusercontent.com/906558/177049960-f4699f06-8631-439d-ade2-f198ace9833d.mov

