### PR TITLE
Limit notification tests to 3 seconds

### DIFF
--- a/Sources/GpgTapNotifierAgent/DeliveryMechanism/DeliveryMechanism.swift
+++ b/Sources/GpgTapNotifierAgent/DeliveryMechanism/DeliveryMechanism.swift
@@ -16,6 +16,16 @@ protocol DeliveryMechanism {
     /// should store internal state on whether or not a true dismissal is
     /// necessary.
     mutating func dismiss()
+
+    /// Any operations needed to finish before a test reminder can be presented.
+    mutating func setupForReminderTest() async
+}
+
+extension DeliveryMechanism {
+    // This is an optional protocol method that no-ops by default.
+    func setupForReminderTest() async {
+        return
+    }
 }
 
 enum PresentStopReason {

--- a/Sources/GpgTapNotifierAgent/DeliveryMechanism/DeliveryMechanismNotification.swift
+++ b/Sources/GpgTapNotifierAgent/DeliveryMechanism/DeliveryMechanismNotification.swift
@@ -131,6 +131,11 @@ extension DeliveryMechanismNotification: DeliveryMechanism {
         presentingState.continuation.resume(returning: .dismissed)
         UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [presentingState.currentNotificationIdentifier])
     }
+
+    func setupForReminderTest() async {
+        performSetupIfNecessary()
+        await requestInitialNotificationAuthorization()
+    }
 }
 
 extension DeliveryMechanismNotification: UNUserNotificationCenterDelegate {

--- a/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
+++ b/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
@@ -155,6 +155,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         var deliveryMechanism = autoReloadingDeliveryMechanism.get()
 
+        // This call may trigger a notification permission request. If that's
+        // the case, the agent should not close/exit before the user has acted
+        // on the request.
+        await deliveryMechanism.setupForReminderTest()
+
         // Intentionally starting the timeout after the "setupForReminderTest"
         // call above. This races the .present call below, which may finish
         // first.

--- a/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
+++ b/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
@@ -155,11 +155,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         var deliveryMechanism = autoReloadingDeliveryMechanism.get()
 
-        let title = "Test Reminder"
-        let body = "This is a test reminder from GPG Tap Notifier."
+        // Intentionally starting the timeout after the "setupForReminderTest"
+        // call above. This races the .present call below, which may finish
+        // first.
+        let presentTimeoutTask = Task {
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            deliveryMechanism.dismiss()
+        }
 
+        let title = "Test Reminder"
+        let body = "This is a test reminder from GPG Tap Notifier that will clear after 3 seconds."
         // TODO: Check if there was an error and save it to UserDefaults for GUI to present.
         let _ = await deliveryMechanism.present(title: title, body: body)
+
+        // If the user manually dismissed the reminder, this task may still be
+        // running. Cancel it for good measure.
+        presentTimeoutTask.cancel()
 
         // Wait 50ms before exiting the application. Without this delay clicking
         // on a notification to dismiss it intermittently caused macOS to show


### PR DESCRIPTION
Followup to the "_Test Notification_" message introduced in https://github.com/palantir/gpg-tap-notifier-macos/pull/12. The test reminder now dismisses itself after 3 seconds.

If the agent needs to request permission to show notifications, that time is not included in the 3 second timeout.

## Demo


https://user-images.githubusercontent.com/906558/177477813-f6198fb8-ed71-4fc3-8da3-fa06a462dd6c.mov


