### PR TITLE
Allow notification test to be canceled

### DIFF
--- a/Sources/GPG Tap Notifier.xcodeproj/project.pbxproj
+++ b/Sources/GPG Tap Notifier.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		46377DF9285596440075A92E /* OpenConfigurationApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46377DF8285596440075A92E /* OpenConfigurationApp.swift */; };
+		46410EC32872484400043A1E /* AgentTestReminderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46410EC22872484400043A1E /* AgentTestReminderViewModel.swift */; };
 		46476798284EFC9900A7E6C9 /* DeliveryMechanism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46476797284EFC9900A7E6C9 /* DeliveryMechanism.swift */; };
 		4647679A284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46476799284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift */; };
 		4647679C284F009E00A7E6C9 /* DeliveryMechanismAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4647679B284F009E00A7E6C9 /* DeliveryMechanismAlert.swift */; };
@@ -72,6 +73,7 @@
 
 /* Begin PBXFileReference section */
 		46377DF8285596440075A92E /* OpenConfigurationApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenConfigurationApp.swift; sourceTree = "<group>"; };
+		46410EC22872484400043A1E /* AgentTestReminderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentTestReminderViewModel.swift; sourceTree = "<group>"; };
 		46476797284EFC9900A7E6C9 /* DeliveryMechanism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanism.swift; sourceTree = "<group>"; };
 		46476799284EFD2D00A7E6C9 /* DeliveryMechanismNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismNotification.swift; sourceTree = "<group>"; };
 		4647679B284F009E00A7E6C9 /* DeliveryMechanismAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismAlert.swift; sourceTree = "<group>"; };
@@ -193,6 +195,7 @@
 			isa = PBXGroup;
 			children = (
 				835F7A9427DEC8C60046D482 /* GpgAgentConfViewModel.swift */,
+				46410EC22872484400043A1E /* AgentTestReminderViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -450,6 +453,7 @@
 				83C2E71B27E4464900FB7743 /* FilePathsView.swift in Sources */,
 				837F1DF827CADB1F00C249DA /* GpgTapNotifierApp.swift in Sources */,
 				837FD81C27E6BA3500CDD61B /* ReminderTextEditView.swift in Sources */,
+				46410EC32872484400043A1E /* AgentTestReminderViewModel.swift in Sources */,
 				464CDAF72870EFE300EAF1AD /* DeliveryMechanismTestButtonView.swift in Sources */,
 				835F7A9327DE87D30046D482 /* AsyncUtils.swift in Sources */,
 				46A442572856FA980012CE9A /* DeliveryMechanismChoiceView.swift in Sources */,

--- a/Sources/GpgTapNotifier/AsyncUtils.swift
+++ b/Sources/GpgTapNotifier/AsyncUtils.swift
@@ -8,6 +8,15 @@ enum RunProcessError: Error {
     case nonZeroExit(Int32)
 }
 
+extension RunProcessError : LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .execError(let error): return "The process failed to start: \(error)"
+        case .nonZeroExit(let exitCode): return "Process exited with non-zero code: \(exitCode)"
+        }
+    }
+}
+
 /// Wraps Process.run to make it an async function. Standard out and error are not captured.
 func run(_ url: URL, arguments: [String]) async throws {
     let process = Process()

--- a/Sources/GpgTapNotifier/AsyncUtils.swift
+++ b/Sources/GpgTapNotifier/AsyncUtils.swift
@@ -10,17 +10,25 @@ enum RunProcessError: Error {
 
 /// Wraps Process.run to make it an async function. Standard out and error are not captured.
 func run(_ url: URL, arguments: [String]) async throws {
-    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(), Error>) in
-        do {
-            try Process.run(url, arguments: arguments) { task in
+    let process = Process()
+    process.executableURL = url
+    process.arguments = arguments
+
+    return try await withTaskCancellationHandler(handler: { process.interrupt() }) {
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(), Error>) in
+            process.terminationHandler = { task in
                 if task.terminationStatus == 0 {
                     continuation.resume(returning: ())
                 } else {
                     continuation.resume(throwing: RunProcessError.nonZeroExit(task.terminationStatus))
                 }
             }
-        } catch {
-            continuation.resume(throwing: RunProcessError.execError(error))
+
+            do {
+                try process.run()
+            } catch {
+                continuation.resume(throwing: RunProcessError.execError(error))
+            }
         }
     }
 }

--- a/Sources/GpgTapNotifier/ViewModel/AgentTestReminderViewModel.swift
+++ b/Sources/GpgTapNotifier/ViewModel/AgentTestReminderViewModel.swift
@@ -44,6 +44,13 @@ class AgentTestNotificationViewModel: ObservableObject {
 
         state = .running(runTask)
     }
+
+    func cancel() {
+        switch state {
+        case .idle, .errored(_): break
+        case .running(let runTask): runTask.cancel()
+        }
+    }
 }
 
 func testNotification() async throws {

--- a/Sources/GpgTapNotifier/ViewModel/AgentTestReminderViewModel.swift
+++ b/Sources/GpgTapNotifier/ViewModel/AgentTestReminderViewModel.swift
@@ -1,0 +1,27 @@
+// Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import Foundation
+
+class AgentTestNotificationViewModel: ObservableObject {
+    @Published var isRunning = false
+    @Published var lastError: Error?
+
+    func test() {
+        Task {
+            self.isRunning = true
+            self.lastError = nil
+            defer { self.isRunning = false }
+
+            do {
+                try await testNotification()
+            } catch {
+                self.lastError = error
+            }
+        }
+    }
+}
+
+func testNotification() async throws {
+    try await run(AGENT_BIN_PATH, arguments: ["--gpg-tap-notifier-test-notification"])
+}

--- a/Sources/GpgTapNotifier/Views/DeliveryMechanismTestButtonView.swift
+++ b/Sources/GpgTapNotifier/Views/DeliveryMechanismTestButtonView.swift
@@ -4,48 +4,32 @@
 import SwiftUI
 
 struct DeliveryMechanismTestButtonView: View {
-    @State private var isTestingNotification = false
-
+    @StateObject var agentRunner = AgentTestNotificationViewModel()
     @State private var isErrorPopoverShown = false
-    @State private var lastError: Error?
 
     var body: some View {
         HStack {
             Button(action: { isErrorPopoverShown = true }) {
                 Image(systemName: "exclamationmark.circle")
             }
-            .disabled(lastError == nil)
-            .opacity(lastError == nil ? 0 : 1)
+            .disabled(agentRunner.lastError == nil)
+            .opacity(agentRunner.lastError == nil ? 0 : 1)
             .buttonStyle(.plain)
             .foregroundColor(.red)
             .popover(isPresented: $isErrorPopoverShown) {
                 VStack(alignment: .leading, spacing: 10) {
                     Text("The last notification test failed")
-                    Text(lastError.map { $0.localizedDescription } ?? "")
+                    Text(agentRunner.lastError.map { $0.localizedDescription } ?? "")
                         .font(.caption)
                 }
                 .padding(10)
                 .frame(width: 250)
             }
 
-            Button(action: onClick) {
+            Button(action: agentRunner.test) {
                 Text("Test Notification")
             }
-            .disabled(isTestingNotification)
-        }
-    }
-
-    func onClick() {
-        Task {
-            self.isTestingNotification = true
-            self.lastError = nil
-            defer { self.isTestingNotification = false }
-
-            do {
-                try await testNotification()
-            } catch {
-                self.lastError = error
-            }
+            .disabled(agentRunner.isRunning)
         }
     }
 }
@@ -54,8 +38,4 @@ struct DeliveryMechanismTestView_Previews: PreviewProvider {
     static var previews: some View {
         DeliveryMechanismTestButtonView()
     }
-}
-
-func testNotification() async throws {
-    try await run(AGENT_BIN_PATH, arguments: ["--gpg-tap-notifier-test-notification"])
 }

--- a/Sources/GpgTapNotifier/Views/DeliveryMechanismTestButtonView.swift
+++ b/Sources/GpgTapNotifier/Views/DeliveryMechanismTestButtonView.swift
@@ -9,24 +9,32 @@ struct DeliveryMechanismTestButtonView: View {
 
     var body: some View {
         HStack {
-            Button(action: { isErrorPopoverShown = true }) {
-                Image(systemName: "exclamationmark.circle")
-            }
-            .disabled(agentRunner.lastError == nil)
-            .opacity(agentRunner.lastError == nil ? 0 : 1)
-            .buttonStyle(.plain)
-            .foregroundColor(.red)
-            .popover(isPresented: $isErrorPopoverShown) {
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("The last notification test failed")
-                    Text(agentRunner.lastError.map { $0.localizedDescription } ?? "")
-                        .font(.caption)
+            if let lastError = agentRunner.lastError {
+                Button(action: { isErrorPopoverShown = true }) {
+                    Image(systemName: "exclamationmark.circle")
                 }
-                .padding(10)
-                .frame(width: 250)
+                .buttonStyle(.plain)
+                .foregroundColor(.red)
+                .onHover { isErrorPopoverShown = $0 }
+                .popover(isPresented: $isErrorPopoverShown) {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("The last notification test failed")
+                        Text(lastError.localizedDescription)
+                            .font(.caption)
+                    }
+                    .padding(10)
+                    .frame(minWidth: 200, maxWidth: 250)
+                }
             }
 
-            Button(action: agentRunner.test) {
+            if (agentRunner.isRunning) {
+                Button(action: agentRunner.cancel) {
+                    Image(systemName: "x.circle")
+                }
+                .buttonStyle(.plain)
+            }
+
+            Button(action: { agentRunner.test() }) {
                 Text("Test Notification")
             }
             .disabled(agentRunner.isRunning)


### PR DESCRIPTION
Adding a button to kill the `GPG Tap Notifier Agent` after hitting "Test Notification".

<img width="637" alt="Screen Shot 2022-07-06 at 2 26 12 AM" src="https://user-images.githubusercontent.com/906558/177483348-c5478578-1cde-4893-8316-554d5df5761c.png">
