### PR TITLE
Switch default reminder delivery mechanism to Alert from Notification and reduce delay to 0.5s

### DIFF
--- a/Sources/GpgTapNotifierUserDefaults/Sources/GpgTapNotifierUserDefaults/GpgTapNotifierUserDefaults.swift
+++ b/Sources/GpgTapNotifierUserDefaults/Sources/GpgTapNotifierUserDefaults/GpgTapNotifierUserDefaults.swift
@@ -33,7 +33,7 @@ public struct AppUserDefaults  {
 
     public static let reminderDeliveryMechanism = UserDefaultsConfig(
         key: "reminderDeliveryMechanism",
-        getDefault: { ReminderDeliveryMechanismOption.notificationCenter })
+        getDefault: { ReminderDeliveryMechanismOption.alert })
 
     public static let reminderTimeout = UserDefaultsConfig(
         key: "notificationTimeoutSecs",


### PR DESCRIPTION
This switches the delivery mechanism default from *Notification* to *Alert HUD* and reduces the timeout from 1.0s to 0.5s.

  |Before|Now|
  |-|-|
  |<img width="370" alt="Screen Shot 2022-07-06 at 2 58 26 AM" src="https://user-images.githubusercontent.com/906558/177488712-021e5962-e258-44b7-a212-d043b6a17c90.png">|<img width="328" alt="Screen Shot 2022-07-06 at 2 55 09 AM" src="https://user-images.githubusercontent.com/906558/177488440-48caf123-3bf8-4b13-a8d0-176993802672.png">|



<img width="637" alt="Screen Shot 2022-07-06 at 2 47 02 AM" src="https://user-images.githubusercontent.com/906558/177486660-a5665b93-1385-4157-a94b-071b4cbf9d53.png">

I believe this will provide a better out of the box experience for most users. I find that macOS notifications are generally meant for communication (e.g. email, Slack) rather than system utilities. The centered system alert better matches other macOS security prompts (e.g. Touch ID, sudo).