### PR TITLE
Update default notification text to put less emphasis on "reminding"

### DIFF
--- a/Sources/GpgTapNotifierUserDefaults/Sources/GpgTapNotifierUserDefaults/GpgTapNotifierUserDefaults.swift
+++ b/Sources/GpgTapNotifierUserDefaults/Sources/GpgTapNotifierUserDefaults/GpgTapNotifierUserDefaults.swift
@@ -41,11 +41,11 @@ public struct AppUserDefaults  {
 
     public static let reminderTitle = UserDefaultsConfig(
         key: "notificationTitle",
-        getDefault: { "YubiKey Reminder" })
+        getDefault: { "YubiKey Awaiting Tap" })
 
     public static let reminderBody = UserDefaultsConfig(
         key: "notificationBody",
-        getDefault: { "Is your YubiKey blinking? You may need to touch its metal contact." })
+        getDefault: { "A GPG signature has been requested. If you initiated this action, tap your YubiKey's metal contact to confirm." })
 
     public static let automaticallyRestartGpgAgent = UserDefaultsConfig(
         key: "automaticallyRestartGpgAgent",


### PR DESCRIPTION
A teammate gave feedback that this application isn't  "reminding" users as much as it puts a user interface to the act of confirming commit message signatures. I think that's right.

Updating default language accordingly. New text is:

> A GPG signature has been requested. If you initiated this action, tap your YubiKey's metal contact to confirm.

## Before

![Screen Shot 2022-07-25 at 4 00 43 PM](https://user-images.githubusercontent.com/906558/180864177-c547f755-e5c0-4d0a-89de-a8e83ef3ce8a.png)

![Screen Shot 2022-07-25 at 4 01 14 PM](https://user-images.githubusercontent.com/906558/180864255-82b8c646-c421-47a0-b393-d9319baca7fa.png)


## After

![Screen Shot 2022-07-25 at 4 21 13 PM](https://user-images.githubusercontent.com/906558/180867288-657a3dd9-a508-4344-bdaa-bca624ca82e3.png)

![Screen Shot 2022-07-25 at 4 20 52 PM](https://user-images.githubusercontent.com/906558/180867240-37c5f7df-5e76-4a01-b051-0abdf7736f31.png)


