### PR TITLE
Show NSAlert on NSScreen.main

### DIFF
--- a/Sources/GpgTapNotifierAgent/DeliveryMechanism/DeliveryMechanismAlert.swift
+++ b/Sources/GpgTapNotifierAgent/DeliveryMechanism/DeliveryMechanismAlert.swift
@@ -34,7 +34,13 @@ extension DeliveryMechanismAlert: DeliveryMechanism {
         alert.addButton(withTitle: "Open Configuration")
 
         let alertWindow = NSPanel(
-            contentRect: NSRect(x: 0, y: 0, width: 0, height: 0),
+            // Without setting width/height to a non-zero value, the NSAlert
+            // appears to always display on the primary screen instead of
+            // NSScreen.main (the screen with the active window). This can be
+            // jarring and causes the NSAlert animation to fly from one screen
+            // to the other. The 1 x 1 px window ends up not being visible to
+            // users since it's under the NSAlert.
+            contentRect: NSRect(x: 0, y: 0, width: 1, height: 1),
             styleMask: [.borderless],
             backing: .buffered,
             defer: false)


### PR DESCRIPTION
## Problem

A user reported that the `NSAlert` animated from one monitor to another on a dual monitor setup. I was able to reproduce this by having my active window on the non-primary monitor and hitting "_Test Notification_".

https://user-images.githubusercontent.com/906558/181792536-e5ce29f4-8247-4cf0-a99e-22ad5efe1ad2.mov

 ## Changes

Fixing the problem in 2 ways.

1. This problem appears unique to `NSAlert` instances tied to a zero width/height window. Setting the alert window to be 1px x 1px prevents the problem.
2. To prevent a permanent 1px x 1px window from persisting on the screen, we're no longer caching the window. It's mow recreated when the alert appears/disappears.