### PR TITLE
Open a modal alert when agent fails to execute scdaemon process

### DIFF
--- a/Sources/GPG Tap Notifier.xcodeproj/project.pbxproj
+++ b/Sources/GPG Tap Notifier.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		4647679C284F009E00A7E6C9 /* DeliveryMechanismAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4647679B284F009E00A7E6C9 /* DeliveryMechanismAlert.swift */; };
 		464CDAF72870EFE300EAF1AD /* DeliveryMechanismTestButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464CDAF62870EFE300EAF1AD /* DeliveryMechanismTestButtonView.swift */; };
 		464CDAF92870F3E800EAF1AD /* ProgressViewLoadingGpgConf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464CDAF82870F3E800EAF1AD /* ProgressViewLoadingGpgConf.swift */; };
+		466DC527291869A10046B9DD /* OpenScdaemonExecFailAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 466DC526291869A10046B9DD /* OpenScdaemonExecFailAlert.swift */; };
 		4693B649285535C500FCD249 /* DeliveryMechanismChooserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4693B648285535C500FCD249 /* DeliveryMechanismChooserView.swift */; };
 		46979AED28552F3E0026C4FD /* AutoReloadingDeliveryMechanism.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46979AEC28552F3E0026C4FD /* AutoReloadingDeliveryMechanism.swift */; };
 		46A442572856FA980012CE9A /* DeliveryMechanismChoiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A442562856FA980012CE9A /* DeliveryMechanismChoiceView.swift */; };
@@ -79,6 +80,7 @@
 		4647679B284F009E00A7E6C9 /* DeliveryMechanismAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismAlert.swift; sourceTree = "<group>"; };
 		464CDAF62870EFE300EAF1AD /* DeliveryMechanismTestButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismTestButtonView.swift; sourceTree = "<group>"; };
 		464CDAF82870F3E800EAF1AD /* ProgressViewLoadingGpgConf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressViewLoadingGpgConf.swift; sourceTree = "<group>"; };
+		466DC526291869A10046B9DD /* OpenScdaemonExecFailAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenScdaemonExecFailAlert.swift; sourceTree = "<group>"; };
 		4693B648285535C500FCD249 /* DeliveryMechanismChooserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismChooserView.swift; sourceTree = "<group>"; };
 		46979AEC28552F3E0026C4FD /* AutoReloadingDeliveryMechanism.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoReloadingDeliveryMechanism.swift; sourceTree = "<group>"; };
 		46A442562856FA980012CE9A /* DeliveryMechanismChoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryMechanismChoiceView.swift; sourceTree = "<group>"; };
@@ -258,6 +260,7 @@
 				837F1E1A27CADF1F00C249DA /* main.swift */,
 				8345C08C27EA37A3000413FF /* ReadCompletionUtils.swift */,
 				46377DF8285596440075A92E /* OpenConfigurationApp.swift */,
+				466DC526291869A10046B9DD /* OpenScdaemonExecFailAlert.swift */,
 				837F1E1027CADB3500C249DA /* Assets.xcassets */,
 				837F1E1527CADB3500C249DA /* GpgTapNotifierAgent.entitlements */,
 				837F1E1227CADB3500C249DA /* Preview Content */,
@@ -467,6 +470,7 @@
 			files = (
 				46377DF9285596440075A92E /* OpenConfigurationApp.swift in Sources */,
 				4647679C284F009E00A7E6C9 /* DeliveryMechanismAlert.swift in Sources */,
+				466DC527291869A10046B9DD /* OpenScdaemonExecFailAlert.swift in Sources */,
 				837F1E1B27CADF1F00C249DA /* main.swift in Sources */,
 				837F1E0D27CADB3300C249DA /* GpgTapNotifierAgentApp.swift in Sources */,
 				46979AED28552F3E0026C4FD /* AutoReloadingDeliveryMechanism.swift in Sources */,

--- a/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
+++ b/Sources/GpgTapNotifierAgent/GpgTapNotifierAgentApp.swift
@@ -54,6 +54,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } catch {
             self.logger.error("Failed to start scdaemon at \(scdaemonPath.path): \(error.localizedDescription)")
             try? FileHandle.standardError.write(contentsOf: Data("Failed to start scdaemon at \(scdaemonPath.path): \(error.localizedDescription)\n".utf8))
+            openScdaemonExecFailAlert(scdaemonPath: scdaemonPath, error: error)
             exit(1)
         }
     }

--- a/Sources/GpgTapNotifierAgent/OpenScdaemonExecFailAlert.swift
+++ b/Sources/GpgTapNotifierAgent/OpenScdaemonExecFailAlert.swift
@@ -1,0 +1,40 @@
+// Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+import AppKit
+import Foundation
+
+func openScdaemonExecFailAlert(scdaemonPath: URL, error: Error) {
+    let alert = NSAlert()
+
+    alert.alertStyle = .critical
+    alert.messageText = "Failed to start scdaemon"
+    alert.informativeText = """
+    Error: \(error.localizedDescription)
+
+    We recommend opening the configuration app and checking that the chosen scdaemon path is valid.
+
+    Current path: \(scdaemonPath.path)
+    """
+
+    // NOTE: According to AppKit docs, the order buttons are added affect
+    // what code they're assigned in the modalResponse.
+    alert.addButton(withTitle: "Open Configuration")
+    alert.addButton(withTitle: "Cancel")
+
+    // The main.swift file sets ActivationPolicy.prohibited to prevent the
+    // daemon from showing in the macOS dock. When there's a critical error, it
+    // may be more helpful to show a dock icon to associate the alert with.
+    NSApplication.shared.setActivationPolicy(.regular)
+
+    alert.window.center()
+
+    // The .runModal() method runs synchronously and all event processing is
+    // blocked. This is normally a problem, but fine when showing a critical
+    // alert immediately before application exit.
+    let modalResponse = alert.runModal()
+
+    if modalResponse == NSApplication.ModalResponse.alertFirstButtonReturn {
+        openConfigurationApp()
+    }
+}


### PR DESCRIPTION
## Problem

A user reported their GPG setup showing strange errors asking them to "_Please insert card with serial number..._" and root caused it to `scdaemon` paths changing after a `brew upgrade`. This change should make it more clear in future scenarios that GPG Tap Notifier configuration is incorrect.

Process execution failure information is currently logged to stderr and the macOS unified logging system, but it'd be more helpful to surface this visually.

## Changes

A modal alert now appears if scdaemon failed to execute. This will now appear alongside the "_Please insert card with serial number..._" error from GPG itself.

<img width="372" alt="Screenshot 2022-11-07 at 12 42 44 AM" src="https://user-images.githubusercontent.com/906558/200234698-c222f7ee-2c5b-4d54-9583-45afa3c97711.png">

## Followups

It'd also be helpful to show status indicators in the GPG Tap Notifier configuration app when one of the selected paths are missing.